### PR TITLE
Remove stale webpack-dev-server entry from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: rails server
-assets: ./bin/webpack-dev-server


### PR DESCRIPTION
## Summary
- Drop the `assets: ./bin/webpack-dev-server` line — leftover from the Webpacker era. The Frontend repo now uses Vite (its own dev server) and Backend has no asset pipeline.
- Procfile is now just `web: rails server`.

## Test plan
- [x] `cat Procfile` shows only `web: rails server`.
- [ ] Boot Rails locally (`rails server`) and confirm the app comes up — no longer relevant to this Procfile, but the umbrella `Procfile` continues to drive dev.

## Related umbrella changes (separate, non-git directory)
The umbrella `Procfile` and `Procfile.e2e` (in `~/Repositories/Websites/Flyweight/`, not a git repo) were also cleaned up in the same hardening pass:
- Removed dead `jobs:` lines (good_job was replaced by QStash HTTP endpoints in `b96c08e`).
- Synced `rvm 3.4.6@flyweight` and `rvm 4.0.2@flyweight` invocations to `rvm 4.0.3@flyweight` (the canonical version pinned in `.ruby-version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)