### PR TITLE
Wire Resend ActionMailer delivery for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem "pg"
 # VIEWS
 gem "jbuilder"
 
+# MAIL
+gem "resend"
+
 # ERRORS
 gem "sentry-rails"
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.5)
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
@@ -182,6 +183,10 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     hashdiff (1.2.1)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -217,6 +222,8 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
     net-imap (0.6.3)
       date
       net-protocol
@@ -323,6 +330,9 @@ GEM
       connection_pool
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.3.0)
+      base64
+      httparty (>= 0.22.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -455,6 +465,7 @@ DEPENDENCIES
   rails-controller-testing
   redcarpet
   redis
+  resend
   responders
   rodauth-rails
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,12 +49,9 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Set host to be used by links generated in mailer templates.
-  # config.action_mailer.default_url_options = {host: "example.com"}
+  config.action_mailer.delivery_method     = :resend
+  config.action_mailer.perform_deliveries  = true
+  config.action_mailer.default_url_options = {host: Rails.application.config.urls.frontend}
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Resend.api_key = ENV["RESEND_API_KEY"] if ENV["RESEND_API_KEY"]


### PR DESCRIPTION
## Summary
- Adds the official `resend` gem and switches production `ActionMailer.delivery_method` to `:resend`, restoring mail delivery for Rodauth reset_password (and the upcoming verify_account flow) which was silently failing in prod.
- Sets `default_url_options` from the existing `config.urls.frontend` so mailer-generated links point at the frontend host.
- Adds `config/initializers/resend.rb` that only sets `Resend.api_key` when `RESEND_API_KEY` is present, so dev/test boot without the env var. Test env stays at `:test`.

## Required Fly secret
- `RESEND_API_KEY` — will be set out of band on `flyweight-backend` by the user post-merge. The wiring only references the env var name; no key value is committed.

## Test plan
- [x] `bundle exec rspec spec` — same 26 pre-existing failures as `main`, no new failures introduced
- [x] `RAILS_ENV=test bundle exec rails runner 'p ActionMailer::Base.delivery_method'` -> `:test`
- [x] Confirmed `config.action_mailer.delivery_method = :resend` line is in `config/environments/production.rb` (RAILS_ENV=production runner cannot boot in worktree without prod credentials/DB)
- [ ] Post-merge: set `RESEND_API_KEY` Fly secret, deploy, send a test reset_password email