### PR TITLE
Validate Cloudflare Turnstile tokens on signup, login, and password-reset

### DIFF
--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -100,8 +100,9 @@ class RodauthApp < Rodauth::Rails::App
 
     # ── Turnstile (Cloudflare CAPTCHA) ────────────────────────────────────
 
-    require_turnstile = lambda do
+    require_turnstile = -> do
       next if Rails.env.test?
+
       token = param_or_nil("turnstile_token")
       unless TurnstileVerifier.verify(token, request.ip).success?
         response.status = 400

--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -98,12 +98,30 @@ class RodauthApp < Rodauth::Rails::App
     webauthn_keys_sign_count_column :sign_count
     webauthn_keys_last_use_column :last_use
 
+    # ── Turnstile (Cloudflare CAPTCHA) ────────────────────────────────────
+
+    require_turnstile = lambda do
+      next if Rails.env.test?
+      token = param_or_nil("turnstile_token")
+      unless TurnstileVerifier.verify(token, request.ip).success?
+        response.status = 400
+        response["Content-Type"] = "application/json"
+        response.write({"error" => "captcha verification failed"}.to_json)
+        request.halt
+      end
+    end
+
     # ── Account creation ──────────────────────────────────────────────────
 
     before_create_account do
+      instance_exec(&require_turnstile)
       account[:name] = param("name")
       account[:created_at] = Time.current
       account[:updated_at] = Time.current
+    end
+
+    before_login do
+      instance_exec(&require_turnstile)
     end
 
     create_account_autologin? true
@@ -145,6 +163,7 @@ class RodauthApp < Rodauth::Rails::App
     # Always return 204 regardless of whether the email exists.
     before_reset_password_request_route do
       if request.post?
+        instance_exec(&require_turnstile)
         if (login = param_or_nil(login_param)) && account_from_login(login) && open_account? && !reset_password_email_recently_sent?
           generate_reset_password_key_value
           transaction do

--- a/app/services/turnstile_verifier.rb
+++ b/app/services/turnstile_verifier.rb
@@ -9,13 +9,11 @@ class TurnstileVerifier
 
   def self.verify(token, remote_ip)
     secret = ENV.fetch("TURNSTILE_SECRET_KEY") do
-      if Rails.env.development? || Rails.env.test? || Rails.env.cypress?
-        "1x0000000000000000000000000000000AA" # Cloudflare always-passes test secret
-      else
-        raise "TURNSTILE_SECRET_KEY missing"
-      end
+      raise "TURNSTILE_SECRET_KEY missing" unless Rails.env.local? || Rails.env.cypress?
+
+      "1x0000000000000000000000000000000AA" # Cloudflare always-passes test secret
     end
-    return Result.new(success?: false, error_codes: ["missing-input-response"]) if token.blank?
+    return Result.new(success?: false, error_codes: %w[missing-input-response]) if token.blank?
 
     http = Net::HTTP.new(ENDPOINT.host, ENDPOINT.port)
     http.use_ssl = true
@@ -26,8 +24,8 @@ class TurnstileVerifier
     res = http.request(req)
     data = JSON.parse(res.body)
     Result.new(success?: data["success"] == true, error_codes: data["error-codes"] || [])
-  rescue => e
+  rescue StandardError => e
     Sentry.add_breadcrumb(Sentry::Breadcrumb.new(category: "turnstile", message: e.message)) if defined?(Sentry)
-    Result.new(success?: false, error_codes: ["network-error"])
+    Result.new(success?: false, error_codes: %w[network-error])
   end
 end

--- a/app/services/turnstile_verifier.rb
+++ b/app/services/turnstile_verifier.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+class TurnstileVerifier
+  Result = Struct.new(:success?, :error_codes, keyword_init: true)
+  ENDPOINT = URI("https://challenges.cloudflare.com/turnstile/v0/siteverify")
+
+  def self.verify(token, remote_ip)
+    secret = ENV.fetch("TURNSTILE_SECRET_KEY") do
+      if Rails.env.development? || Rails.env.test? || Rails.env.cypress?
+        "1x0000000000000000000000000000000AA" # Cloudflare always-passes test secret
+      else
+        raise "TURNSTILE_SECRET_KEY missing"
+      end
+    end
+    return Result.new(success?: false, error_codes: ["missing-input-response"]) if token.blank?
+
+    http = Net::HTTP.new(ENDPOINT.host, ENDPOINT.port)
+    http.use_ssl = true
+    http.open_timeout = 10
+    http.read_timeout = 10
+    req = Net::HTTP::Post.new(ENDPOINT.path)
+    req.set_form_data(secret: secret, response: token, remoteip: remote_ip.to_s)
+    res = http.request(req)
+    data = JSON.parse(res.body)
+    Result.new(success?: data["success"] == true, error_codes: data["error-codes"] || [])
+  rescue => e
+    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(category: "turnstile", message: e.message)) if defined?(Sentry)
+    Result.new(success?: false, error_codes: ["network-error"])
+  end
+end

--- a/spec/requests/auth/login_turnstile_spec.rb
+++ b/spec/requests/auth/login_turnstile_spec.rb
@@ -7,24 +7,24 @@ RSpec.describe "POST /login with Turnstile" do
   let(:pilot) { create :pilot, password: }
 
   context "when Turnstile verification succeeds" do
-    before do
+    before(:each) do
       allow(TurnstileVerifier).to receive(:verify).
-        and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
+          and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
     end
 
     it "logs the user in" do
+      expect(TurnstileVerifier).to receive(:verify).with("tok", anything)
       post "/login", params: {login: pilot.email, password:, turnstile_token: "tok"}, as: :json
       expect(response).to have_http_status(:success)
       expect(response.parsed_body["access_token"]).to be_present
-      expect(TurnstileVerifier).to have_received(:verify).with("tok", anything)
     end
   end
 
   context "when Turnstile verification fails" do
-    before do
+    before(:each) do
       allow(TurnstileVerifier).to receive(:verify).
-        and_return(TurnstileVerifier::Result.new(success?: false, error_codes: ["invalid-input-response"]))
+          and_return(TurnstileVerifier::Result.new(success?: false, error_codes: %w[invalid-input-response]))
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
     end
 

--- a/spec/requests/auth/login_turnstile_spec.rb
+++ b/spec/requests/auth/login_turnstile_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /login with Turnstile" do
+  let(:password) { FFaker::Internet.password }
+  let(:pilot) { create :pilot, password: }
+
+  context "when Turnstile verification succeeds" do
+    before do
+      allow(TurnstileVerifier).to receive(:verify).
+        and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
+    end
+
+    it "logs the user in" do
+      post "/login", params: {login: pilot.email, password:, turnstile_token: "tok"}, as: :json
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body["access_token"]).to be_present
+      expect(TurnstileVerifier).to have_received(:verify).with("tok", anything)
+    end
+  end
+
+  context "when Turnstile verification fails" do
+    before do
+      allow(TurnstileVerifier).to receive(:verify).
+        and_return(TurnstileVerifier::Result.new(success?: false, error_codes: ["invalid-input-response"]))
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
+    end
+
+    it "returns 400 and does not issue a token" do
+      post "/login", params: {login: pilot.email, password:, turnstile_token: "bad"}, as: :json
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["access_token"]).to be_blank
+    end
+  end
+end

--- a/spec/requests/auth/password_reset_turnstile_spec.rb
+++ b/spec/requests/auth/password_reset_turnstile_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /password-resets with Turnstile" do
+  let(:pilot) { create :pilot }
+
+  context "when Turnstile verification succeeds" do
+    before do
+      allow(TurnstileVerifier).to receive(:verify).
+        and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
+    end
+
+    it "sends a password-reset email" do
+      post "/password-resets", params: {login: pilot.email, turnstile_token: "tok"}, as: :json
+      expect(response).to have_http_status(:no_content)
+      expect(ActionMailer::Base.deliveries.last).to be_present
+      expect(TurnstileVerifier).to have_received(:verify).with("tok", anything)
+    end
+  end
+
+  context "when Turnstile verification fails" do
+    before do
+      allow(TurnstileVerifier).to receive(:verify).
+        and_return(TurnstileVerifier::Result.new(success?: false, error_codes: ["invalid-input-response"]))
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
+    end
+
+    it "returns 400 and does not send an email" do
+      ActionMailer::Base.deliveries.clear
+      post "/password-resets", params: {login: pilot.email, turnstile_token: "bad"}, as: :json
+      expect(response).to have_http_status(:bad_request)
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+end

--- a/spec/requests/auth/password_reset_turnstile_spec.rb
+++ b/spec/requests/auth/password_reset_turnstile_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe "POST /password-resets with Turnstile" do
   let(:pilot) { create :pilot }
 
   context "when Turnstile verification succeeds" do
-    before do
+    before(:each) do
       allow(TurnstileVerifier).to receive(:verify).
-        and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
+          and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
     end
 
     it "sends a password-reset email" do
+      expect(TurnstileVerifier).to receive(:verify).with("tok", anything)
       post "/password-resets", params: {login: pilot.email, turnstile_token: "tok"}, as: :json
       expect(response).to have_http_status(:no_content)
       expect(ActionMailer::Base.deliveries.last).to be_present
-      expect(TurnstileVerifier).to have_received(:verify).with("tok", anything)
     end
   end
 
   context "when Turnstile verification fails" do
-    before do
+    before(:each) do
       allow(TurnstileVerifier).to receive(:verify).
-        and_return(TurnstileVerifier::Result.new(success?: false, error_codes: ["invalid-input-response"]))
+          and_return(TurnstileVerifier::Result.new(success?: false, error_codes: %w[invalid-input-response]))
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
     end
 

--- a/spec/requests/auth/signup_turnstile_spec.rb
+++ b/spec/requests/auth/signup_turnstile_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /signup with Turnstile" do
+  let(:params) { {login: "tsig@example.com", password: "securepass", name: "Tee", turnstile_token: "tok"} }
+
+  context "when Turnstile verification succeeds" do
+    before do
+      allow(TurnstileVerifier).to receive(:verify).
+        and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
+      # Force the rodauth hook out of test-bypass mode for this example.
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
+    end
+
+    it "creates the account" do
+      post "/signup", params: params, as: :json
+      expect(response).to have_http_status(:success)
+      expect(TurnstileVerifier).to have_received(:verify).with("tok", anything)
+    end
+  end
+
+  context "when Turnstile verification fails" do
+    before do
+      allow(TurnstileVerifier).to receive(:verify).
+        and_return(TurnstileVerifier::Result.new(success?: false, error_codes: ["invalid-input-response"]))
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
+    end
+
+    it "returns 400 and does not create the account" do
+      expect {
+        post "/signup", params: params, as: :json
+      }.not_to change(Pilot, :count)
+      expect(response).to have_http_status(:bad_request)
+      body = response.parsed_body
+      expect(body["error"] || body["field-error"]).to be_present
+    end
+  end
+end

--- a/spec/requests/auth/signup_turnstile_spec.rb
+++ b/spec/requests/auth/signup_turnstile_spec.rb
@@ -6,31 +6,31 @@ RSpec.describe "POST /signup with Turnstile" do
   let(:params) { {login: "tsig@example.com", password: "securepass", name: "Tee", turnstile_token: "tok"} }
 
   context "when Turnstile verification succeeds" do
-    before do
+    before(:each) do
       allow(TurnstileVerifier).to receive(:verify).
-        and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
+          and_return(TurnstileVerifier::Result.new(success?: true, error_codes: []))
       # Force the rodauth hook out of test-bypass mode for this example.
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
     end
 
     it "creates the account" do
+      expect(TurnstileVerifier).to receive(:verify).with("tok", anything)
       post "/signup", params: params, as: :json
       expect(response).to have_http_status(:success)
-      expect(TurnstileVerifier).to have_received(:verify).with("tok", anything)
     end
   end
 
   context "when Turnstile verification fails" do
-    before do
+    before(:each) do
       allow(TurnstileVerifier).to receive(:verify).
-        and_return(TurnstileVerifier::Result.new(success?: false, error_codes: ["invalid-input-response"]))
+          and_return(TurnstileVerifier::Result.new(success?: false, error_codes: %w[invalid-input-response]))
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("cypress"))
     end
 
     it "returns 400 and does not create the account" do
-      expect {
+      expect do
         post "/signup", params: params, as: :json
-      }.not_to change(Pilot, :count)
+      end.not_to change(Pilot, :count)
       expect(response).to have_http_status(:bad_request)
       body = response.parsed_body
       expect(body["error"] || body["field-error"]).to be_present

--- a/spec/services/turnstile_verifier_spec.rb
+++ b/spec/services/turnstile_verifier_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TurnstileVerifier do
+  let(:endpoint) { "https://challenges.cloudflare.com/turnstile/v0/siteverify" }
+
+  describe ".verify" do
+    it "returns success when Cloudflare returns success: true" do
+      stub_request(:post, endpoint).
+        with(body: hash_including("response" => "good-token", "remoteip" => "1.2.3.4")).
+        to_return(status: 200, body: {success: true}.to_json)
+
+      result = described_class.verify("good-token", "1.2.3.4")
+      expect(result.success?).to be true
+      expect(result.error_codes).to eq([])
+    end
+
+    it "returns failure with error codes when Cloudflare returns success: false" do
+      stub_request(:post, endpoint).
+        to_return(status: 200, body: {success: false, "error-codes": ["invalid-input-response"]}.to_json)
+
+      result = described_class.verify("bad-token", "1.2.3.4")
+      expect(result.success?).to be false
+      expect(result.error_codes).to eq(["invalid-input-response"])
+    end
+
+    it "returns failure with network-error on timeout" do
+      stub_request(:post, endpoint).to_timeout
+
+      result = described_class.verify("any-token", "1.2.3.4")
+      expect(result.success?).to be false
+      expect(result.error_codes).to eq(["network-error"])
+    end
+
+    it "returns failure with missing-input-response when token is blank" do
+      result = described_class.verify("", "1.2.3.4")
+      expect(result.success?).to be false
+      expect(result.error_codes).to eq(["missing-input-response"])
+
+      result = described_class.verify(nil, "1.2.3.4")
+      expect(result.success?).to be false
+      expect(result.error_codes).to eq(["missing-input-response"])
+    end
+
+    it "uses Cloudflare's always-passes test secret as a fallback in test env" do
+      # No TURNSTILE_SECRET_KEY env var; test env should fall back without raising.
+      expect(ENV["TURNSTILE_SECRET_KEY"]).to be_nil
+      stub_request(:post, endpoint).
+        with(body: hash_including("secret" => "1x0000000000000000000000000000000AA")).
+        to_return(status: 200, body: {success: true}.to_json)
+
+      result = described_class.verify("any-token", "1.2.3.4")
+      expect(result.success?).to be true
+    end
+  end
+end

--- a/spec/services/turnstile_verifier_spec.rb
+++ b/spec/services/turnstile_verifier_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe TurnstileVerifier do
   describe ".verify" do
     it "returns success when Cloudflare returns success: true" do
       stub_request(:post, endpoint).
-        with(body: hash_including("response" => "good-token", "remoteip" => "1.2.3.4")).
-        to_return(status: 200, body: {success: true}.to_json)
+          with(body: hash_including("response" => "good-token", "remoteip" => "1.2.3.4")).
+          to_return(status: 200, body: {success: true}.to_json)
 
       result = described_class.verify("good-token", "1.2.3.4")
       expect(result.success?).to be true
@@ -18,11 +18,11 @@ RSpec.describe TurnstileVerifier do
 
     it "returns failure with error codes when Cloudflare returns success: false" do
       stub_request(:post, endpoint).
-        to_return(status: 200, body: {success: false, "error-codes": ["invalid-input-response"]}.to_json)
+          to_return(status: 200, body: {success: false, "error-codes": %w[invalid-input-response]}.to_json)
 
       result = described_class.verify("bad-token", "1.2.3.4")
       expect(result.success?).to be false
-      expect(result.error_codes).to eq(["invalid-input-response"])
+      expect(result.error_codes).to eq(%w[invalid-input-response])
     end
 
     it "returns failure with network-error on timeout" do
@@ -30,25 +30,25 @@ RSpec.describe TurnstileVerifier do
 
       result = described_class.verify("any-token", "1.2.3.4")
       expect(result.success?).to be false
-      expect(result.error_codes).to eq(["network-error"])
+      expect(result.error_codes).to eq(%w[network-error])
     end
 
     it "returns failure with missing-input-response when token is blank" do
       result = described_class.verify("", "1.2.3.4")
       expect(result.success?).to be false
-      expect(result.error_codes).to eq(["missing-input-response"])
+      expect(result.error_codes).to eq(%w[missing-input-response])
 
       result = described_class.verify(nil, "1.2.3.4")
       expect(result.success?).to be false
-      expect(result.error_codes).to eq(["missing-input-response"])
+      expect(result.error_codes).to eq(%w[missing-input-response])
     end
 
     it "uses Cloudflare's always-passes test secret as a fallback in test env" do
       # No TURNSTILE_SECRET_KEY env var; test env should fall back without raising.
-      expect(ENV["TURNSTILE_SECRET_KEY"]).to be_nil
+      expect(ENV.fetch("TURNSTILE_SECRET_KEY", nil)).to be_nil
       stub_request(:post, endpoint).
-        with(body: hash_including("secret" => "1x0000000000000000000000000000000AA")).
-        to_return(status: 200, body: {success: true}.to_json)
+          with(body: hash_including("secret" => "1x0000000000000000000000000000000AA")).
+          to_return(status: 200, body: {success: true}.to_json)
 
       result = described_class.verify("any-token", "1.2.3.4")
       expect(result.success?).to be true

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "webmock/rspec"
+
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
## Summary
- New `TurnstileVerifier` service (stdlib `Net::HTTP`) that posts the user's token to Cloudflare's `siteverify` endpoint.
- Wires the verifier into Rodauth's `before_create_account`, `before_login`, and `before_reset_password_request_route` hooks. Failures return `400 {"error":"captcha verification failed"}`.
- Adds unit specs for the verifier (success/failure/timeout/blank-token/test-secret fallback) and request specs for each protected endpoint.

This is the third bot-defense layer in the hardening batch (after rack-attack and `:verify_account`). It blocks headless-browser traffic that doesn't render the JS challenge.

## Operator action required
- Set `TURNSTILE_SECRET_KEY` as a Fly secret on the backend app **out of band** before merging — this PR does not contain or reference any production secret. The frontend already (or will, via F2) embed the matching `TURNSTILE_SITE_KEY`.
- Cloudflare's documented always-passes test secret (`1x0000000000000000000000000000000AA`) is the dev / test / cypress fallback so the validation path is fully exercised in CI without any real CAPTCHA round-trip.

## Notes
- The hook short-circuits in `Rails.env.test?` so existing request specs pass without modification. New turnstile specs override this by stubbing `TurnstileVerifier.verify` and overriding `Rails.env`.
- `webmock` (already in the test group) is required via `spec/support/webmock.rb` and configured to allow localhost.

Pairs with FlyWeight-org/Frontend F2 (Turnstile widget rendering).

## Test plan
- [x] `bundle exec rspec spec` — 87 examples, 0 failures
- [x] Manual cypress-env smoke: `POST /signup` with `turnstile_token: "X"` → 200 + JWT; without token → 400
- [x] Manual cypress-env smoke: `POST /login` with token → 200; without → 400
- [x] Manual cypress-env smoke: `POST /password-resets` with token → 204; without → 400