### PR TITLE
Enable Rodauth :verify_account; new signups must verify email

### DIFF
--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -11,6 +11,7 @@ class RodauthApp < Rodauth::Rails::App
     # ── Features ──────────────────────────────────────────────────────────
 
     enable :login, :logout, :create_account, :close_account,
+           :verify_account,
            :reset_password, :change_password, :change_login,
            :jwt, :jwt_refresh,
            :webauthn, :webauthn_login, :webauthn_autofill
@@ -30,6 +31,7 @@ class RodauthApp < Rodauth::Rails::App
     login_route "login"
     logout_route "logout"
     create_account_route "signup"
+    verify_account_route "verify-account"
     reset_password_request_route "password-resets"
     reset_password_route "reset-password"
     # jwt_refresh_route uses default "jwt-refresh"
@@ -54,6 +56,13 @@ class RodauthApp < Rodauth::Rails::App
       h = super()
       h["e"] = account[:email] if account
       h
+    end
+
+    # Suppress the empty JWT that Rodauth would otherwise emit when the
+    # session contains no account_id (e.g. after an unverified signup or
+    # a failed login attempt).
+    set_jwt_token do |token|
+      super(token) if session[session_key]
     end
 
     # ── JWT refresh keys table ────────────────────────────────────────────
@@ -84,6 +93,14 @@ class RodauthApp < Rodauth::Rails::App
       token_key = convert_email_token_key(reset_password_key_value)
       token = "#{account_id}#{token_separator}#{token_key}"
       "Reset your password: #{frontend}/reset-password?key=#{token}"
+    end
+
+    verify_account_email_subject "Verify your FlyWeight account"
+    verify_account_email_body do
+      frontend = Rails.application.config.urls.frontend
+      token_key = convert_email_token_key(verify_account_key_value)
+      token = "#{account_id}#{token_separator}#{token_key}"
+      "Verify your FlyWeight account: #{frontend}/verify-account?key=#{token}"
     end
 
     # ── WebAuthn ──────────────────────────────────────────────────────────
@@ -125,14 +142,17 @@ class RodauthApp < Rodauth::Rails::App
       instance_exec(&require_turnstile)
     end
 
-    create_account_autologin? true
+    # :verify_account suppresses autologin until the account is verified.
+    create_account_autologin? false
+    # Password is captured at signup, not at verification time.
+    verify_account_set_password? false
 
     # ── Account closure ───────────────────────────────────────────────────
 
     delete_account_on_close? true
 
     # ── Response customization ────────────────────────────────────────────
-    # Add pilot profile data to login and signup responses.
+    # Add pilot profile data to the login response.
 
     after_login do
       pilot = Pilot.find(account_id)
@@ -141,13 +161,6 @@ class RodauthApp < Rodauth::Rails::App
       json_response["passkeys"] = pilot.webauthn_keys.order(:last_use).map do |k|
         {"id" => k.webauthn_id, "label" => k.label, "last_used_at" => k.last_use}
       end
-    end
-
-    after_create_account do
-      pilot = Pilot.find(account_id)
-      json_response["name"] = pilot.name
-      json_response["email"] = pilot.email
-      json_response["passkeys"] = []
     end
 
     # Apply an optional label to a newly registered passkey.

--- a/db/migrate/20260428231722_create_account_verification_keys.rb
+++ b/db/migrate/20260428231722_create_account_verification_keys.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateAccountVerificationKeys < ActiveRecord::Migration[8.1]
+  def change
+    create_table :account_verification_keys, id: false do |t|
+      t.bigint :id, primary_key: true # rubocop:disable Rails/DangerousColumnNames -- Rodauth convention: id is FK to pilots
+      t.string :key, null: false
+      t.datetime :requested_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_foreign_key :account_verification_keys, :pilots, column: :id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260428231723_change_pilots_status_id_default.rb
+++ b/db/migrate/20260428231723_change_pilots_status_id_default.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangePilotsStatusIdDefault < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :pilots, :status_id, from: 2, to: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_231723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000005) do
     t.datetime "deadline", null: false
     t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "key", null: false
+  end
+
+  create_table "account_verification_keys", force: :cascade do |t|
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "key", null: false
+    t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
   create_table "account_webauthn_keys", primary_key: ["account_id", "webauthn_id"], force: :cascade do |t|
@@ -71,13 +77,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000005) do
     t.string "email", default: "", null: false
     t.string "name", null: false
     t.string "password_hash"
-    t.integer "status_id", default: 2, null: false
+    t.integer "status_id", default: 1, null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_pilots_on_email", unique: true
   end
 
   add_foreign_key "account_jwt_refresh_keys", "pilots", on_delete: :cascade
   add_foreign_key "account_password_reset_keys", "pilots", column: "id", on_delete: :cascade
+  add_foreign_key "account_verification_keys", "pilots", column: "id", on_delete: :cascade
   add_foreign_key "account_webauthn_keys", "pilots", column: "account_id", on_delete: :cascade
   add_foreign_key "account_webauthn_user_ids", "pilots", column: "id", on_delete: :cascade
   add_foreign_key "flights", "pilots", on_delete: :cascade

--- a/spec/factories/pilots.rb
+++ b/spec/factories/pilots.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     sequence(:email) { |i| "email-#{i}@example.com" }
     password { FFaker::Internet.password }
     status_id { 2 }
+
+    trait :unverified do
+      status_id { 1 }
+    end
   end
 end

--- a/spec/requests/auth/verify_account_spec.rb
+++ b/spec/requests/auth/verify_account_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "/verify-account" do
+  let(:email) { "verify@example.com" }
+  let(:password) { "hunter22!" }
+
+  def signup
+    post "/signup",
+         params: {login: email, password:, name: "Verify Me"},
+         as:     :json
+  end
+
+  def verification_keys
+    ActiveRecord::Base.connection.select_all("SELECT * FROM account_verification_keys")
+  end
+
+  def token_from_last_email
+    body = ActionMailer::Base.deliveries.last.body.decoded
+    body.match(/key=([^\s]+)/)[1]
+  end
+
+  describe "POST /signup" do
+    it "creates an unverified pilot and a verification key, with no JWT in the response" do
+      expect { signup }.to change(Pilot, :count).by(1).
+          and change { verification_keys.count }.by(1)
+
+      expect(response).to have_http_status(:success)
+      pilot = Pilot.find_by!(email: email)
+      expect(pilot.status_id).to eq(1)
+
+      expect(response.headers["Authorization"]).to be_blank
+      expect(response.headers["Refresh-Token"]).to be_blank
+      body = response.parsed_body
+      expect(body["access_token"]).to be_blank
+      expect(body["refresh_token"]).to be_blank
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail).to be_present
+      expect(mail.subject).to eq("Verify your FlyWeight account")
+      expect(mail.body.decoded).to include("/verify-account?key=")
+    end
+  end
+
+  describe "POST /login (unverified)" do
+    it "rejects the login with the Rodauth unverified-account error" do
+      signup
+      pilot = Pilot.find_by!(email: email)
+      expect(pilot.status_id).to eq(1)
+
+      post "/login",
+           params: {login: email, password:},
+           as:     :json
+      expect(response).to have_http_status(:forbidden)
+      body = response.parsed_body
+      expect(body["error"]).to be_present
+      expect(response.headers["Authorization"]).to be_blank
+    end
+  end
+
+  describe "POST /verify-account" do
+    let(:pilot) { Pilot.find_by!(email: email) }
+
+    before { signup }
+
+    it "verifies the account and removes the verification key" do
+      post "/verify-account", params: {key: token_from_last_email}, as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(pilot.reload.status_id).to eq(2)
+      expect(verification_keys.count).to eq(0)
+    end
+
+    it "rejects an invalid key" do
+      post "/verify-account", params: {key: "bogus"}, as: :json
+      expect(response).to have_http_status(:unauthorized)
+      expect(pilot.reload.status_id).to eq(1)
+    end
+
+    it "allows login after verification with a JWT" do
+      post "/verify-account", params: {key: token_from_last_email}, as: :json
+      expect(response).to have_http_status(:success)
+
+      post "/login", params: {login: email, password:}, as: :json
+      expect(response).to have_http_status(:success)
+      body = response.parsed_body
+      expect(body["access_token"]).to be_present
+      expect(body["refresh_token"]).to be_present
+      expect(response.headers["Authorization"]).to be_present
+    end
+  end
+end

--- a/spec/requests/auth/verify_account_spec.rb
+++ b/spec/requests/auth/verify_account_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "/verify-account" do
     ActiveRecord::Base.connection.select_all("SELECT * FROM account_verification_keys")
   end
 
+  def verification_key_count
+    verification_keys.count
+  end
+
   def token_from_last_email
     body = ActionMailer::Base.deliveries.last.body.decoded
     body.match(/key=([^\s]+)/)[1]
@@ -24,7 +28,7 @@ RSpec.describe "/verify-account" do
   describe "POST /signup" do
     it "creates an unverified pilot and a verification key, with no JWT in the response" do
       expect { signup }.to change(Pilot, :count).by(1).
-          and change { verification_keys.count }.by(1)
+          and change(self, :verification_key_count).by(1)
 
       expect(response).to have_http_status(:success)
       pilot = Pilot.find_by!(email: email)
@@ -62,7 +66,7 @@ RSpec.describe "/verify-account" do
   describe "POST /verify-account" do
     let(:pilot) { Pilot.find_by!(email: email) }
 
-    before { signup }
+    before(:each) { signup }
 
     it "verifies the account and removes the verification key" do
       post "/verify-account", params: {key: token_from_last_email}, as: :json

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe "Account" do
   let(:pilot) { create :pilot, password: current_password }
 
   describe "POST /signup" do
-    it "creates a pilot and returns tokens" do
+    it "creates an unverified pilot without returning tokens" do
       post "/signup",
            params: {login: "new@example.com", password: "securepass", name: "New Pilot"},
            as:     :json
       expect(response).to have_http_status(:success)
+      pilot = Pilot.find_by!(email: "new@example.com")
+      expect(pilot.name).to eq("New Pilot")
+      expect(pilot.status_id).to eq(1)
       body = response.parsed_body
-      expect(body["name"]).to eq("New Pilot")
-      expect(body["email"]).to eq("new@example.com")
-      expect(body["passkeys"]).to eq([])
-      expect(body["access_token"]).to be_present
-      expect(body["refresh_token"]).to be_present
+      expect(body["access_token"]).to be_blank
+      expect(body["refresh_token"]).to be_blank
     end
 
     it "handles validation errors" do


### PR DESCRIPTION
## Summary

Closes the spam-signup loophole: until now, Rodauth shipped without `:verify_account`, so new signups landed at `status_id = 2` (open) and were autologged in. Disposable-domain bots have been creating accounts at scale.

With this change:

- New signups land at `status_id = 1` (unverified) and a row is inserted into `account_verification_keys`.
- The signup response contains no JWT pair (no `Authorization` header, no `access_token`/`refresh_token` in the body).
- A login attempt before verification returns `403` with a Rodauth JSON error.
- Clicking the link in the verification email (`POST /verify-account` with `key=<id>_<hmac>`) flips `status_id` to `2` and removes the verification row.
- After verification, login works normally and returns a JWT pair.

### Backwards compatibility

- Existing rows are unaffected. They stay at `status_id = 2` (open) and are grandfathered as verified — there is no retroactive verification challenge.
- Only the column default flips from `2` to `1`, so new signups default unverified.

### Dependencies

- Mail delivery is required for the verification email to actually go out in production. Pairs with B1 (Resend mail).
- `verify_account_set_password? false` — the password is still captured at signup, not at verification time, matching the single-step flow.
- Wave 2 (B6) will convert the plain-text email body to multipart HTML.

### Implementation notes

- `create_account_autologin?` is set to `false` explicitly because configure-block overrides win against the verify_account feature default.
- `set_jwt_token` is overridden to no-op when `session[:account_id]` is empty, so Rodauth doesn't emit an empty JWT (just `exp/iat/nbf/e`) for unverified signups or failed logins.
- The `after_create_account` block that injected `name`/`email`/`passkeys` into the signup response is removed — those fields are unverified-account info that shouldn't leak.

### Pairs with

- TODO: Frontend verify-account view (F1) — open in parallel.

## Test plan

- [x] `bundle exec rspec spec` — 81 examples, 0 failures (includes the new `spec/requests/auth/verify_account_spec.rb` covering signup → unverified login rejection → verify-account → login-after-verification).
- [ ] E2E with the curl flow in the task description — skipped: the worktree's cypress env points at the shared `flyweight_test` DB. Worth running locally before merge if the harden/turnstile-backend branch isn't being landed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)