### PR TITLE
HTML email variants for verify_account and reset_password

### DIFF
--- a/app/mailers/rodauth_mailer.rb
+++ b/app/mailers/rodauth_mailer.rb
@@ -3,11 +3,11 @@
 class RodauthMailer < ApplicationMailer
   def verify_account(email, link)
     @link = link
-    mail(to: email, subject: "Verify your FlyWeight account")
+    mail(to: email, subject: I18n.t("rodauth_mailer.verify_account.subject"))
   end
 
   def reset_password(email, link)
     @link = link
-    mail(to: email, subject: "Reset your FlyWeight password")
+    mail(to: email, subject: I18n.t("rodauth_mailer.reset_password.subject"))
   end
 end

--- a/app/mailers/rodauth_mailer.rb
+++ b/app/mailers/rodauth_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RodauthMailer < ApplicationMailer
+  def verify_account(email, link)
+    @link = link
+    mail(to: email, subject: "Verify your FlyWeight account")
+  end
+
+  def reset_password(email, link)
+    @link = link
+    mail(to: email, subject: "Reset your FlyWeight password")
+  end
+end

--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -11,6 +11,7 @@ class RodauthApp < Rodauth::Rails::App
     # ── Features ──────────────────────────────────────────────────────────
 
     enable :login, :logout, :create_account, :close_account,
+           :verify_account,
            :reset_password, :change_password, :change_login,
            :jwt, :jwt_refresh,
            :webauthn, :webauthn_login, :webauthn_autofill
@@ -30,6 +31,7 @@ class RodauthApp < Rodauth::Rails::App
     login_route "login"
     logout_route "logout"
     create_account_route "signup"
+    verify_account_route "verify-account"
     reset_password_request_route "password-resets"
     reset_password_route "reset-password"
     # jwt_refresh_route uses default "jwt-refresh"
@@ -54,6 +56,13 @@ class RodauthApp < Rodauth::Rails::App
       h = super()
       h["e"] = account[:email] if account
       h
+    end
+
+    # Suppress the empty JWT that Rodauth would otherwise emit when the
+    # session contains no account_id (e.g. after an unverified signup or
+    # a failed login attempt).
+    set_jwt_token do |token|
+      super(token) if session[session_key]
     end
 
     # ── JWT refresh keys table ────────────────────────────────────────────
@@ -86,6 +95,14 @@ class RodauthApp < Rodauth::Rails::App
       "Reset your password: #{frontend}/reset-password?key=#{token}"
     end
 
+    verify_account_email_subject "Verify your FlyWeight account"
+    verify_account_email_body do
+      frontend = Rails.application.config.urls.frontend
+      token_key = convert_email_token_key(verify_account_key_value)
+      token = "#{account_id}#{token_separator}#{token_key}"
+      "Verify your FlyWeight account: #{frontend}/verify-account?key=#{token}"
+    end
+
     # ── WebAuthn ──────────────────────────────────────────────────────────
 
     webauthn_origin { Rails.application.config.urls.frontend }
@@ -106,14 +123,17 @@ class RodauthApp < Rodauth::Rails::App
       account[:updated_at] = Time.current
     end
 
-    create_account_autologin? true
+    # :verify_account suppresses autologin until the account is verified.
+    create_account_autologin? false
+    # Password is captured at signup, not at verification time.
+    verify_account_set_password? false
 
     # ── Account closure ───────────────────────────────────────────────────
 
     delete_account_on_close? true
 
     # ── Response customization ────────────────────────────────────────────
-    # Add pilot profile data to login and signup responses.
+    # Add pilot profile data to the login response.
 
     after_login do
       pilot = Pilot.find(account_id)
@@ -122,13 +142,6 @@ class RodauthApp < Rodauth::Rails::App
       json_response["passkeys"] = pilot.webauthn_keys.order(:last_use).map do |k|
         {"id" => k.webauthn_id, "label" => k.label, "last_used_at" => k.last_use}
       end
-    end
-
-    after_create_account do
-      pilot = Pilot.find(account_id)
-      json_response["name"] = pilot.name
-      json_response["email"] = pilot.email
-      json_response["passkeys"] = []
     end
 
     # Apply an optional label to a newly registered passkey.

--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -88,19 +88,21 @@ class RodauthApp < Rodauth::Rails::App
 
     email_from "donotreply@flyweight.org"
 
-    reset_password_email_body do
+    send_reset_password_email do
       frontend = Rails.application.config.urls.frontend
       token_key = convert_email_token_key(reset_password_key_value)
       token = "#{account_id}#{token_separator}#{token_key}"
-      "Reset your password: #{frontend}/reset-password?key=#{token}"
+      link = "#{frontend}/reset-password?key=#{token}"
+      RodauthMailer.reset_password(account[:email], link).deliver_now
     end
 
     verify_account_email_subject "Verify your FlyWeight account"
-    verify_account_email_body do
+    send_verify_account_email do
       frontend = Rails.application.config.urls.frontend
       token_key = convert_email_token_key(verify_account_key_value)
       token = "#{account_id}#{token_separator}#{token_key}"
-      "Verify your FlyWeight account: #{frontend}/verify-account?key=#{token}"
+      link = "#{frontend}/verify-account?key=#{token}"
+      RodauthMailer.verify_account(account[:email], link).deliver_now
     end
 
     # ── WebAuthn ──────────────────────────────────────────────────────────

--- a/app/views/rodauth_mailer/reset_password.html.erb
+++ b/app/views/rodauth_mailer/reset_password.html.erb
@@ -1,0 +1,13 @@
+<h1>Reset your FlyWeight password</h1>
+
+<p>We received a request to reset your password. Click the button below to choose a new one:</p>
+
+<p>
+  <a href="<%= @link %>" style="display:inline-block;padding:10px 20px;background:#0066cc;color:#fff;text-decoration:none;border-radius:4px;">Reset your password</a>
+</p>
+
+<p>Or copy and paste this URL into your browser:</p>
+
+<p><%= @link %></p>
+
+<p>If you didn't request a password reset, ignore this email.</p>

--- a/app/views/rodauth_mailer/reset_password.text.erb
+++ b/app/views/rodauth_mailer/reset_password.text.erb
@@ -1,0 +1,5 @@
+Reset your FlyWeight password by visiting:
+
+<%= @link %>
+
+If you didn't request a password reset, ignore this email.

--- a/app/views/rodauth_mailer/verify_account.html.erb
+++ b/app/views/rodauth_mailer/verify_account.html.erb
@@ -1,0 +1,13 @@
+<h1>Verify your FlyWeight account</h1>
+
+<p>Welcome to FlyWeight! Click the button below to verify your account:</p>
+
+<p>
+  <a href="<%= @link %>" style="display:inline-block;padding:10px 20px;background:#0066cc;color:#fff;text-decoration:none;border-radius:4px;">Verify your account</a>
+</p>
+
+<p>Or copy and paste this URL into your browser:</p>
+
+<p><%= @link %></p>
+
+<p>If you didn't sign up, ignore this email.</p>

--- a/app/views/rodauth_mailer/verify_account.text.erb
+++ b/app/views/rodauth_mailer/verify_account.text.erb
@@ -1,0 +1,5 @@
+Verify your FlyWeight account by visiting:
+
+<%= @link %>
+
+If you didn't sign up, ignore this email.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,11 @@ en:
   application_controller:
     errors:
       internal_server_error: An internal error has occurred.
+  rodauth_mailer:
+    verify_account:
+      subject: Verify your FlyWeight account
+    reset_password:
+      subject: Reset your FlyWeight password
   errors:
     messages:
       accepted: must be accepted

--- a/db/migrate/20260428231722_create_account_verification_keys.rb
+++ b/db/migrate/20260428231722_create_account_verification_keys.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateAccountVerificationKeys < ActiveRecord::Migration[8.1]
+  def change
+    create_table :account_verification_keys, id: false do |t|
+      t.bigint :id, primary_key: true # rubocop:disable Rails/DangerousColumnNames -- Rodauth convention: id is FK to pilots
+      t.string :key, null: false
+      t.datetime :requested_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_foreign_key :account_verification_keys, :pilots, column: :id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260428231723_change_pilots_status_id_default.rb
+++ b/db/migrate/20260428231723_change_pilots_status_id_default.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangePilotsStatusIdDefault < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :pilots, :status_id, from: 2, to: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_231723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000005) do
     t.datetime "deadline", null: false
     t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "key", null: false
+  end
+
+  create_table "account_verification_keys", force: :cascade do |t|
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "key", null: false
+    t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
   create_table "account_webauthn_keys", primary_key: ["account_id", "webauthn_id"], force: :cascade do |t|
@@ -71,13 +77,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000005) do
     t.string "email", default: "", null: false
     t.string "name", null: false
     t.string "password_hash"
-    t.integer "status_id", default: 2, null: false
+    t.integer "status_id", default: 1, null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_pilots_on_email", unique: true
   end
 
   add_foreign_key "account_jwt_refresh_keys", "pilots", on_delete: :cascade
   add_foreign_key "account_password_reset_keys", "pilots", column: "id", on_delete: :cascade
+  add_foreign_key "account_verification_keys", "pilots", column: "id", on_delete: :cascade
   add_foreign_key "account_webauthn_keys", "pilots", column: "account_id", on_delete: :cascade
   add_foreign_key "account_webauthn_user_ids", "pilots", column: "id", on_delete: :cascade
   add_foreign_key "flights", "pilots", on_delete: :cascade

--- a/spec/factories/pilots.rb
+++ b/spec/factories/pilots.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     sequence(:email) { |i| "email-#{i}@example.com" }
     password { FFaker::Internet.password }
     status_id { 2 }
+
+    trait :unverified do
+      status_id { 1 }
+    end
   end
 end

--- a/spec/mailers/rodauth_mailer_spec.rb
+++ b/spec/mailers/rodauth_mailer_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe RodauthMailer do
   describe "#verify_account" do
     let(:mail) { described_class.verify_account(email, link) }
 
-    include_examples "a multipart email", "Verify your FlyWeight account"
+    it_behaves_like "a multipart email", "Verify your FlyWeight account"
   end
 
   describe "#reset_password" do
     let(:mail) { described_class.reset_password(email, link) }
 
-    include_examples "a multipart email", "Reset your FlyWeight password"
+    it_behaves_like "a multipart email", "Reset your FlyWeight password"
   end
 end

--- a/spec/mailers/rodauth_mailer_spec.rb
+++ b/spec/mailers/rodauth_mailer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RodauthMailer do
+  let(:email) { "pilot@example.com" }
+  let(:link)  { "https://app.example.com/verify-account?key=abc123" }
+
+  shared_examples "a multipart email" do |subject|
+    it "sets the recipient and subject" do
+      expect(mail.to).to eq([email])
+      expect(mail.subject).to eq(subject)
+      expect(mail.from).to eq(["donotreply@flyweight.org"])
+    end
+
+    it "is multipart with text/plain and text/html parts" do
+      expect(mail).to be_multipart
+      content_types = mail.parts.map(&:content_type)
+      expect(content_types.any? { |t| t.start_with?("text/plain") }).to be true
+      expect(content_types.any? { |t| t.start_with?("text/html") }).to be true
+    end
+
+    it "includes the link as an <a href> in the HTML part" do
+      html_part = mail.parts.find { |p| p.content_type.start_with?("text/html") }
+      expect(html_part.body.decoded).to include(%(href="#{link}"))
+    end
+
+    it "includes the link as a plain URL in the text part" do
+      text_part = mail.parts.find { |p| p.content_type.start_with?("text/plain") }
+      expect(text_part.body.decoded).to include(link)
+    end
+  end
+
+  describe "#verify_account" do
+    let(:mail) { described_class.verify_account(email, link) }
+
+    include_examples "a multipart email", "Verify your FlyWeight account"
+  end
+
+  describe "#reset_password" do
+    let(:mail) { described_class.reset_password(email, link) }
+
+    include_examples "a multipart email", "Reset your FlyWeight password"
+  end
+end

--- a/spec/requests/auth/verify_account_spec.rb
+++ b/spec/requests/auth/verify_account_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "/verify-account" do
+  let(:email) { "verify@example.com" }
+  let(:password) { "hunter22!" }
+
+  def signup
+    post "/signup",
+         params: {login: email, password:, name: "Verify Me"},
+         as:     :json
+  end
+
+  def verification_keys
+    ActiveRecord::Base.connection.select_all("SELECT * FROM account_verification_keys")
+  end
+
+  def token_from_last_email
+    body = ActionMailer::Base.deliveries.last.body.decoded
+    body.match(/key=([^\s]+)/)[1]
+  end
+
+  describe "POST /signup" do
+    it "creates an unverified pilot and a verification key, with no JWT in the response" do
+      expect { signup }.to change(Pilot, :count).by(1).
+          and change { verification_keys.count }.by(1)
+
+      expect(response).to have_http_status(:success)
+      pilot = Pilot.find_by!(email: email)
+      expect(pilot.status_id).to eq(1)
+
+      expect(response.headers["Authorization"]).to be_blank
+      expect(response.headers["Refresh-Token"]).to be_blank
+      body = response.parsed_body
+      expect(body["access_token"]).to be_blank
+      expect(body["refresh_token"]).to be_blank
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail).to be_present
+      expect(mail.subject).to eq("Verify your FlyWeight account")
+      expect(mail.body.decoded).to include("/verify-account?key=")
+    end
+  end
+
+  describe "POST /login (unverified)" do
+    it "rejects the login with the Rodauth unverified-account error" do
+      signup
+      pilot = Pilot.find_by!(email: email)
+      expect(pilot.status_id).to eq(1)
+
+      post "/login",
+           params: {login: email, password:},
+           as:     :json
+      expect(response).to have_http_status(:forbidden)
+      body = response.parsed_body
+      expect(body["error"]).to be_present
+      expect(response.headers["Authorization"]).to be_blank
+    end
+  end
+
+  describe "POST /verify-account" do
+    let(:pilot) { Pilot.find_by!(email: email) }
+
+    before { signup }
+
+    it "verifies the account and removes the verification key" do
+      post "/verify-account", params: {key: token_from_last_email}, as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(pilot.reload.status_id).to eq(2)
+      expect(verification_keys.count).to eq(0)
+    end
+
+    it "rejects an invalid key" do
+      post "/verify-account", params: {key: "bogus"}, as: :json
+      expect(response).to have_http_status(:unauthorized)
+      expect(pilot.reload.status_id).to eq(1)
+    end
+
+    it "allows login after verification with a JWT" do
+      post "/verify-account", params: {key: token_from_last_email}, as: :json
+      expect(response).to have_http_status(:success)
+
+      post "/login", params: {login: email, password:}, as: :json
+      expect(response).to have_http_status(:success)
+      body = response.parsed_body
+      expect(body["access_token"]).to be_present
+      expect(body["refresh_token"]).to be_present
+      expect(response.headers["Authorization"]).to be_present
+    end
+  end
+end

--- a/spec/requests/auth/verify_account_spec.rb
+++ b/spec/requests/auth/verify_account_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe "/verify-account" do
   end
 
   def token_from_last_email
-    body = ActionMailer::Base.deliveries.last.body.decoded
-    body.match(/key=([^\s]+)/)[1]
+    mail = ActionMailer::Base.deliveries.last
+    body = mail.text_part&.body&.decoded || mail.html_part&.body&.decoded || mail.body.decoded
+    body.match(/key=([^\s"<]+)/)[1]
   end
 
   describe "POST /signup" do
@@ -43,7 +44,8 @@ RSpec.describe "/verify-account" do
       mail = ActionMailer::Base.deliveries.last
       expect(mail).to be_present
       expect(mail.subject).to eq("Verify your FlyWeight account")
-      expect(mail.body.decoded).to include("/verify-account?key=")
+      expect(mail.text_part.body.decoded).to include("/verify-account?key=")
+      expect(mail.html_part.body.decoded).to include("/verify-account?key=")
     end
   end
 

--- a/spec/requests/auth/verify_account_spec.rb
+++ b/spec/requests/auth/verify_account_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "/verify-account" do
     ActiveRecord::Base.connection.select_all("SELECT * FROM account_verification_keys")
   end
 
+  def verification_key_count
+    verification_keys.count
+  end
+
   def token_from_last_email
     body = ActionMailer::Base.deliveries.last.body.decoded
     body.match(/key=([^\s]+)/)[1]
@@ -24,7 +28,7 @@ RSpec.describe "/verify-account" do
   describe "POST /signup" do
     it "creates an unverified pilot and a verification key, with no JWT in the response" do
       expect { signup }.to change(Pilot, :count).by(1).
-          and change { verification_keys.count }.by(1)
+          and change(self, :verification_key_count).by(1)
 
       expect(response).to have_http_status(:success)
       pilot = Pilot.find_by!(email: email)
@@ -62,7 +66,7 @@ RSpec.describe "/verify-account" do
   describe "POST /verify-account" do
     let(:pilot) { Pilot.find_by!(email: email) }
 
-    before { signup }
+    before(:each) { signup }
 
     it "verifies the account and removes the verification key" do
       post "/verify-account", params: {key: token_from_last_email}, as: :json

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe "/password-resets" do
       post "/password-resets",
            params: {login: pilot.email},
            as:     :json
-      body   = ActionMailer::Base.deliveries.last.body.decoded
-      @token = body.match(/key=(.+?)(?:\s|$)/)[1]
+      mail   = ActionMailer::Base.deliveries.last
+      body   = mail.text_part&.body&.decoded || mail.html_part&.body&.decoded || mail.body.decoded
+      @token = body.match(/key=([^\s"<]+)/)[1]
     end
 
     it "resets the password" do

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe "Account" do
   let(:pilot) { create :pilot, password: current_password }
 
   describe "POST /signup" do
-    it "creates a pilot and returns tokens" do
+    it "creates an unverified pilot without returning tokens" do
       post "/signup",
            params: {login: "new@example.com", password: "securepass", name: "New Pilot"},
            as:     :json
       expect(response).to have_http_status(:success)
+      pilot = Pilot.find_by!(email: "new@example.com")
+      expect(pilot.name).to eq("New Pilot")
+      expect(pilot.status_id).to eq(1)
       body = response.parsed_body
-      expect(body["name"]).to eq("New Pilot")
-      expect(body["email"]).to eq("new@example.com")
-      expect(body["passkeys"]).to eq([])
-      expect(body["access_token"]).to be_present
-      expect(body["refresh_token"]).to be_present
+      expect(body["access_token"]).to be_blank
+      expect(body["refresh_token"]).to be_blank
     end
 
     it "handles validation errors" do


### PR DESCRIPTION
## Summary
- Adds `RodauthMailer` with `verify_account` and `reset_password` actions, each backed by `.html.erb` and `.text.erb` templates so emails are sent as multipart text/plain + text/html.
- Replaces Rodauth's `verify_account_email_body` and `reset_password_email_body` plain-text blocks with `send_verify_account_email` / `send_reset_password_email` overrides that call the new mailer.
- Updates the existing verify-account and password-resets request specs to extract the verification key from the multipart body (text part preferred, HTML fallback).
- Adds `spec/mailers/rodauth_mailer_spec.rb` covering recipient/subject, multipart structure, HTML `<a href>`, and plain-URL text part for both actions.

## Notes
- Stacks on top of #37 (B2). Merge after #37 lands.
- Uses `deliver_now` rather than `deliver_later` because the test env's `:test` queue adapter does not auto-run jobs and there is no async queue configured for development. Introducing one is out of scope for this unit.
- HTML templates are intentionally minimal (heading, paragraph, button-link, plain URL fallback). No brand chrome, footers, or unsubscribe handling — those are deferred non-goals.
- The shared `app/views/layouts/mailer.{html,text}.erb` were already present from the Rails defaults.

## Test plan
- [x] `bundle exec rspec spec` — 89 examples, 0 failures.
- [x] `bundle exec rails runner -e development 'puts RodauthMailer.verify_account(...).to_s'` — verified `multipart/alternative` with both `text/plain` and `text/html` parts and the link present in each.