### PR TITLE
HTML email variants for verify_account and reset_password

### DIFF
--- a/app/mailers/rodauth_mailer.rb
+++ b/app/mailers/rodauth_mailer.rb
@@ -3,11 +3,11 @@
 class RodauthMailer < ApplicationMailer
   def verify_account(email, link)
     @link = link
-    mail(to: email, subject: "Verify your FlyWeight account")
+    mail(to: email, subject: I18n.t("rodauth_mailer.verify_account.subject"))
   end
 
   def reset_password(email, link)
     @link = link
-    mail(to: email, subject: "Reset your FlyWeight password")
+    mail(to: email, subject: I18n.t("rodauth_mailer.reset_password.subject"))
   end
 end

--- a/app/mailers/rodauth_mailer.rb
+++ b/app/mailers/rodauth_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RodauthMailer < ApplicationMailer
+  def verify_account(email, link)
+    @link = link
+    mail(to: email, subject: "Verify your FlyWeight account")
+  end
+
+  def reset_password(email, link)
+    @link = link
+    mail(to: email, subject: "Reset your FlyWeight password")
+  end
+end

--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -88,19 +88,21 @@ class RodauthApp < Rodauth::Rails::App
 
     email_from "donotreply@flyweight.org"
 
-    reset_password_email_body do
+    send_reset_password_email do
       frontend = Rails.application.config.urls.frontend
       token_key = convert_email_token_key(reset_password_key_value)
       token = "#{account_id}#{token_separator}#{token_key}"
-      "Reset your password: #{frontend}/reset-password?key=#{token}"
+      link = "#{frontend}/reset-password?key=#{token}"
+      RodauthMailer.reset_password(account[:email], link).deliver_now
     end
 
     verify_account_email_subject "Verify your FlyWeight account"
-    verify_account_email_body do
+    send_verify_account_email do
       frontend = Rails.application.config.urls.frontend
       token_key = convert_email_token_key(verify_account_key_value)
       token = "#{account_id}#{token_separator}#{token_key}"
-      "Verify your FlyWeight account: #{frontend}/verify-account?key=#{token}"
+      link = "#{frontend}/verify-account?key=#{token}"
+      RodauthMailer.verify_account(account[:email], link).deliver_now
     end
 
     # ── WebAuthn ──────────────────────────────────────────────────────────

--- a/app/views/rodauth_mailer/reset_password.html.erb
+++ b/app/views/rodauth_mailer/reset_password.html.erb
@@ -1,0 +1,13 @@
+<h1>Reset your FlyWeight password</h1>
+
+<p>We received a request to reset your password. Click the button below to choose a new one:</p>
+
+<p>
+  <a href="<%= @link %>" style="display:inline-block;padding:10px 20px;background:#0066cc;color:#fff;text-decoration:none;border-radius:4px;">Reset your password</a>
+</p>
+
+<p>Or copy and paste this URL into your browser:</p>
+
+<p><%= @link %></p>
+
+<p>If you didn't request a password reset, ignore this email.</p>

--- a/app/views/rodauth_mailer/reset_password.text.erb
+++ b/app/views/rodauth_mailer/reset_password.text.erb
@@ -1,0 +1,5 @@
+Reset your FlyWeight password by visiting:
+
+<%= @link %>
+
+If you didn't request a password reset, ignore this email.

--- a/app/views/rodauth_mailer/verify_account.html.erb
+++ b/app/views/rodauth_mailer/verify_account.html.erb
@@ -1,0 +1,13 @@
+<h1>Verify your FlyWeight account</h1>
+
+<p>Welcome to FlyWeight! Click the button below to verify your account:</p>
+
+<p>
+  <a href="<%= @link %>" style="display:inline-block;padding:10px 20px;background:#0066cc;color:#fff;text-decoration:none;border-radius:4px;">Verify your account</a>
+</p>
+
+<p>Or copy and paste this URL into your browser:</p>
+
+<p><%= @link %></p>
+
+<p>If you didn't sign up, ignore this email.</p>

--- a/app/views/rodauth_mailer/verify_account.text.erb
+++ b/app/views/rodauth_mailer/verify_account.text.erb
@@ -1,0 +1,5 @@
+Verify your FlyWeight account by visiting:
+
+<%= @link %>
+
+If you didn't sign up, ignore this email.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,11 @@ en:
   application_controller:
     errors:
       internal_server_error: An internal error has occurred.
+  rodauth_mailer:
+    verify_account:
+      subject: Verify your FlyWeight account
+    reset_password:
+      subject: Reset your FlyWeight password
   errors:
     messages:
       accepted: must be accepted

--- a/spec/mailers/rodauth_mailer_spec.rb
+++ b/spec/mailers/rodauth_mailer_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe RodauthMailer do
   describe "#verify_account" do
     let(:mail) { described_class.verify_account(email, link) }
 
-    include_examples "a multipart email", "Verify your FlyWeight account"
+    it_behaves_like "a multipart email", "Verify your FlyWeight account"
   end
 
   describe "#reset_password" do
     let(:mail) { described_class.reset_password(email, link) }
 
-    include_examples "a multipart email", "Reset your FlyWeight password"
+    it_behaves_like "a multipart email", "Reset your FlyWeight password"
   end
 end

--- a/spec/mailers/rodauth_mailer_spec.rb
+++ b/spec/mailers/rodauth_mailer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RodauthMailer do
+  let(:email) { "pilot@example.com" }
+  let(:link)  { "https://app.example.com/verify-account?key=abc123" }
+
+  shared_examples "a multipart email" do |subject|
+    it "sets the recipient and subject" do
+      expect(mail.to).to eq([email])
+      expect(mail.subject).to eq(subject)
+      expect(mail.from).to eq(["donotreply@flyweight.org"])
+    end
+
+    it "is multipart with text/plain and text/html parts" do
+      expect(mail).to be_multipart
+      content_types = mail.parts.map(&:content_type)
+      expect(content_types.any? { |t| t.start_with?("text/plain") }).to be true
+      expect(content_types.any? { |t| t.start_with?("text/html") }).to be true
+    end
+
+    it "includes the link as an <a href> in the HTML part" do
+      html_part = mail.parts.find { |p| p.content_type.start_with?("text/html") }
+      expect(html_part.body.decoded).to include(%(href="#{link}"))
+    end
+
+    it "includes the link as a plain URL in the text part" do
+      text_part = mail.parts.find { |p| p.content_type.start_with?("text/plain") }
+      expect(text_part.body.decoded).to include(link)
+    end
+  end
+
+  describe "#verify_account" do
+    let(:mail) { described_class.verify_account(email, link) }
+
+    include_examples "a multipart email", "Verify your FlyWeight account"
+  end
+
+  describe "#reset_password" do
+    let(:mail) { described_class.reset_password(email, link) }
+
+    include_examples "a multipart email", "Reset your FlyWeight password"
+  end
+end

--- a/spec/requests/auth/verify_account_spec.rb
+++ b/spec/requests/auth/verify_account_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe "/verify-account" do
   end
 
   def token_from_last_email
-    body = ActionMailer::Base.deliveries.last.body.decoded
-    body.match(/key=([^\s]+)/)[1]
+    mail = ActionMailer::Base.deliveries.last
+    body = mail.text_part&.body&.decoded || mail.html_part&.body&.decoded || mail.body.decoded
+    body.match(/key=([^\s"<]+)/)[1]
   end
 
   describe "POST /signup" do
@@ -43,7 +44,8 @@ RSpec.describe "/verify-account" do
       mail = ActionMailer::Base.deliveries.last
       expect(mail).to be_present
       expect(mail.subject).to eq("Verify your FlyWeight account")
-      expect(mail.body.decoded).to include("/verify-account?key=")
+      expect(mail.text_part.body.decoded).to include("/verify-account?key=")
+      expect(mail.html_part.body.decoded).to include("/verify-account?key=")
     end
   end
 

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe "/password-resets" do
       post "/password-resets",
            params: {login: pilot.email},
            as:     :json
-      body   = ActionMailer::Base.deliveries.last.body.decoded
-      @token = body.match(/key=(.+?)(?:\s|$)/)[1]
+      mail   = ActionMailer::Base.deliveries.last
+      body   = mail.text_part&.body&.decoded || mail.html_part&.body&.decoded || mail.body.decoded
+      @token = body.match(/key=([^\s"<]+)/)[1]
     end
 
     it "resets the password" do


### PR DESCRIPTION
Replaces #38 (auto-closed when base branch `harden/verify-account` was deleted on its merge).

## Summary
- New `RodauthMailer` with multipart HTML+text views for verify_account and reset_password
- Replaces Rodauth's built-in plain-text email blocks with mailer overrides
- Subjects pulled from `config/locales/en.yml`

## Test plan
- [x] `bundle exec rspec spec`
- [x] e2e: rendered both mails in cypress env, confirmed multipart with text/plain + text/html parts and styled `<a href>` button to the link
- [x] CI green
