### PR TITLE
Add VerifyRedisConnection middleware for Fly suspend/resume

### DIFF
--- a/app/middleware/verify_redis_connection.rb
+++ b/app/middleware/verify_redis_connection.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Verifies the Rack::Attack Redis connection is alive before each request.
+#
+# Rationale: Fly suspends the VM after idle; the OS clock pauses, so TCP
+# keepalives don't reap dead sockets and the redis-client connection pool
+# still hands out the stale socket on resume. Rack::Attack runs early in
+# the middleware stack, so its first read/write after a resume blocks past
+# Fly's proxy timeout (504). Pinging here lets redis-client detect the dead
+# socket on send and reconnect, absorbing the cost on this side instead of
+# letting it bubble up as a 504.
+#
+# Skips Fly's health-check path. Errors are swallowed: rack-attack falls
+# open on cache failures by design, and a transient Redis blip should not
+# 500 the site.
+
+class VerifyRedisConnection
+
+  SKIP_PATHS = ["/up"].freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if !SKIP_PATHS.include?(env["PATH_INFO"]) && Rack::Attack.cache.store.is_a?(ActiveSupport::Cache::RedisCacheStore)
+      begin
+        Rack::Attack.cache.store.redis.ping
+      rescue StandardError => e
+        Sentry.capture_message("Redis ping failed: #{e.class.name}: #{e.message}") if defined?(Sentry)
+      end
+    end
+    @app.call(env)
+  end
+
+end

--- a/app/middleware/verify_redis_connection.rb
+++ b/app/middleware/verify_redis_connection.rb
@@ -23,14 +23,19 @@ class VerifyRedisConnection
   end
 
   def call(env)
-    if !SKIP_PATHS.include?(env["PATH_INFO"]) && Rack::Attack.cache.store.is_a?(ActiveSupport::Cache::RedisCacheStore)
-      begin
-        Rack::Attack.cache.store.redis.ping
-      rescue StandardError => e
-        Sentry.capture_message("Redis ping failed: #{e.class.name}: #{e.message}") if defined?(Sentry)
-      end
-    end
+    ping_redis unless SKIP_PATHS.include?(env["PATH_INFO"])
     @app.call(env)
+  end
+
+  private
+
+  def ping_redis
+    store = Rack::Attack.cache.store
+    return unless store.kind_of?(ActiveSupport::Cache::RedisCacheStore)
+
+    store.redis.ping
+  rescue StandardError => e
+    Sentry.capture_message("Redis ping failed: #{e.class.name}: #{e.message}") if defined?(Sentry)
   end
 
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,9 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # Reconnect to Postgres if the pooled socket died during Fly suspend.
+  # Reconnect to Redis (rack-attack) and Postgres if pooled sockets died
+  # during Fly suspend. Order matters: Rack::Attack runs early in the stack
+  # and trips Redis before any controller touches AR, so verify Redis first.
+  config.middleware.use VerifyRedisConnection
   config.middleware.use VerifyDatabaseConnection
 end


### PR DESCRIPTION
## Why

Production hung today after Fly auto-suspend/resume. Machine accepted three POST requests, never produced a 'Completed' log line, health checks failed, manual restart fixed it. Almost certainly the rack-attack Redis store hanging on a stale TCP socket — same shape as the Postgres bug commit `838e8f7` already fixed, but Redis had no equivalent guard.

## What

New `VerifyRedisConnection` middleware, mirroring `VerifyDatabaseConnection`. On each non-/up request, pings the rack-attack Redis store. `redis-client` detects a dead socket on send and reconnects transparently, absorbing the cost on the Rails side instead of letting it bubble up as a 504.

Errors are swallowed (rack-attack falls open on cache failures by design; a Redis blip should not 500 the site). Dev/cypress use `MemoryStore`, so the `is_a?(RedisCacheStore)` guard keeps this a no-op there.

Inserted before `VerifyDatabaseConnection` because rack-attack runs early in the stack and trips Redis before any controller touches AR.

## Test plan
- [x] CI green
- [ ] Post-deploy: confirm machine resume after suspend completes a /login (or any auth endpoint) within Fly's proxy timeout instead of hanging
