### PR TITLE
Move Turnstile gates to *_route hooks (close enumeration bypass)

### DIFF
--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -131,17 +131,26 @@ class RodauthApp < Rodauth::Rails::App
       end
     end
 
+    # ── Captcha gates ────────────────────────────────────────────────────
+    # Use *_route hooks so the captcha is required before Rodauth's account
+    # lookup. Otherwise a bot can submit a nonexistent or already-taken
+    # email, get the standard 401/422 back, and never need to solve the
+    # widget — turning these endpoints into a free enumeration oracle.
+
+    before_create_account_route do
+      instance_exec(&require_turnstile) if request.post?
+    end
+
+    before_login_route do
+      instance_exec(&require_turnstile) if request.post?
+    end
+
     # ── Account creation ──────────────────────────────────────────────────
 
     before_create_account do
-      instance_exec(&require_turnstile)
       account[:name] = param("name")
       account[:created_at] = Time.current
       account[:updated_at] = Time.current
-    end
-
-    before_login do
-      instance_exec(&require_turnstile)
     end
 
     # :verify_account suppresses autologin until the account is verified.

--- a/spec/requests/auth/login_turnstile_spec.rb
+++ b/spec/requests/auth/login_turnstile_spec.rb
@@ -33,5 +33,16 @@ RSpec.describe "POST /login with Turnstile" do
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["access_token"]).to be_blank
     end
+
+    # Regression: previously the Turnstile check fired in `before_login`,
+    # which Rodauth only runs after a successful password match. A bot
+    # could POST /login with any email that doesn't exist and get the
+    # standard "no matching login" 401 without ever solving the captcha,
+    # turning /login into a free account-enumeration oracle.
+    it "rejects with captcha error before Rodauth's account lookup runs" do
+      post "/login", params: {login: "nobody@example.com", password: "x", turnstile_token: "bad"}, as: :json
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["error"]).to eq("captcha verification failed")
+    end
   end
 end

--- a/spec/requests/auth/signup_turnstile_spec.rb
+++ b/spec/requests/auth/signup_turnstile_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe "POST /signup with Turnstile" do
     # into an enumeration oracle for known accounts.
     it "rejects with captcha error before Rodauth's already-taken check runs" do
       existing = create :pilot
-      post "/signup",
-          params: {login: existing.email, password: "securepass", name: "Dup", turnstile_token: "bad"},
-          as:     :json
+      dup_params = {login: existing.email, password: "securepass", name: "Dup", turnstile_token: "bad"}
+      post "/signup", params: dup_params, as: :json
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["error"]).to eq("captcha verification failed")
     end

--- a/spec/requests/auth/signup_turnstile_spec.rb
+++ b/spec/requests/auth/signup_turnstile_spec.rb
@@ -35,5 +35,19 @@ RSpec.describe "POST /signup with Turnstile" do
       body = response.parsed_body
       expect(body["error"] || body["field-error"]).to be_present
     end
+
+    # Regression: previously the Turnstile check fired in `before_create_account`,
+    # which Rodauth only runs after all signup validations pass. A bot could
+    # POST /signup with an already-taken email and get a 422 "already an
+    # account" response without ever solving the captcha, turning /signup
+    # into an enumeration oracle for known accounts.
+    it "rejects with captcha error before Rodauth's already-taken check runs" do
+      existing = create :pilot
+      post "/signup",
+          params: {login: existing.email, password: "securepass", name: "Dup", turnstile_token: "bad"},
+          as:     :json
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["error"]).to eq("captcha verification failed")
+    end
   end
 end


### PR DESCRIPTION
## Why

The Turnstile checks added in #36 fire too late in Rodauth's request flow:

- `before_login` only runs *after* a successful password match. `account_from_login` runs first; if the email doesn't exist, Rodauth throws `:no_matching_login` (401) before the Turnstile check ever fires.
- `before_create_account` only runs *after* all signup validations pass. If the email is already taken, Rodauth returns 422 "already an account" before the Turnstile check fires.

Net effect: a bot can hammer `/login` with random emails, or `/signup` with known emails, to enumerate accounts without ever solving the captcha. The rack-attack 10/5min throttle bounds the volume but the gate isn't there.

`/password-resets` is fine — `before_reset_password_request_route` already fires at the route level, before account lookup.

## What

Move the gates to `before_login_route` and `before_create_account_route`. These fire on every request to the route (GET and POST), before Rodauth's own DB lookups, so the captcha is required regardless of whether the email matches a real account. Added `if request.post?` guard since *_route hooks fire on GET too.

## Test plan
- [x] Existing specs still pass
- [x] New regression spec: POST /login with nonexistent email + bad token → 400 "captcha verification failed" (was: 401 "no matching login")
- [x] New regression spec: POST /signup with already-taken email + bad token → 400 "captcha verification failed" (was: 422 "already an account")
