### PR TITLE
Add GET /presence warm-up endpoint

### DIFF
--- a/app/controllers/presence_controller.rb
+++ b/app/controllers/presence_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Lightweight warm-up endpoint. The Frontend pings GET /presence on auth-page
+# mount so the Fly machine, the Postgres pool, and the Redis pool are all
+# already warm by the time the user clicks submit. The work happens in the
+# middleware stack: VerifyRedisConnection and VerifyDatabaseConnection both
+# skip /up but not /presence, so a hit here exercises both pooled
+# connections — letting redis-client and AR detect dead sockets and
+# reconnect transparently.
+#
+# Distinct from /up (rails/health#show), which Fly's health checker hits and
+# which is intentionally exempted from the verify-* middlewares to avoid
+# adding DB/Redis work to every health probe.
+
+class PresenceController < ApplicationController
+
+  def show
+    head :ok
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,10 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # Frontend warm-up ping; goes through the verify-* middlewares so a hit
+  # here wakes Postgres and Redis pools alongside the Fly machine itself.
+  get "presence" => "presence#show"
+
   get "metrics" => "metrics#show" unless Rails.env.test? || Rails.env.cypress?
 
   root to: redirect(Rails.application.config.urls.frontend)

--- a/spec/requests/presence_spec.rb
+++ b/spec/requests/presence_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /presence" do
+  it "returns 200 without auth" do
+    get "/presence"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "is not throttled by rack-attack" do
+    20.times { get "/presence", headers: {"REMOTE_ADDR" => "9.9.9.9"} }
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## Why

Pairs with [Frontend PR _#TBD_]. Frontend pings `GET /presence` on auth-page mount so the Fly machine, Postgres pool, and Redis pool are all already warm by the time the user fills the form and clicks submit. With #40 (Redis verify middleware) deployed, a single ping warms all three.

## What

- New `PresenceController#show` returns `head :ok`. The endpoint does no work itself; the warming happens because the request flows through the production middleware stack:
  - `VerifyRedisConnection` (#40) pings the rack-attack Redis store
  - `VerifyDatabaseConnection` (existing) pings AR
  Both skip `/up` but not `/presence`, so this path exercises both pools.
- No auth, no throttle. Public, fire-and-forget on the client.

Distinct from `/up` (rails/health#show), which Fly's health checker hits and which is intentionally exempted from the verify-* middlewares to avoid putting DB/Redis work on every health probe.

## Test plan
- [x] New spec: GET /presence returns 200 without auth
- [x] New spec: GET /presence is not throttled by rack-attack
- [ ] Post-deploy: `curl -i https://app.flyweight.org/presence` after a suspend → 200
