### PR TITLE
fix: require_relative VerifyRedisConnection in production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 require_relative "../../app/middleware/verify_database_connection"
+require_relative "../../app/middleware/verify_redis_connection"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
Hotfix for #40. The middleware class isn't autoloaded at config-load time, so production.rb needs an explicit require_relative — exactly like the existing line for VerifyDatabaseConnection right above it. Caught by the failed deploy on the #40 merge.